### PR TITLE
Prepare for version 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The add-on can be configured from its category in the NVDA's settings dialog, un
 
 Tip: If you have not configured NVDA to speak typed characters or words but want to hear typed text in passwords, you may create a configuration profile to enable the speaking of typed characters and passwords, and assign it to a gesture or create a trigger to enable it automatically in certain situations. For convenience, NVDA will ask if you want to create a dedicated profile when the add-on is installed.
 
+## Changes for 2.0 ##
+* Compatible with NVDA 2021.1 and beyond.
+
 ## Changes for 1.0 ##
 * Initial version.
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2019.3",
+	"addon_lastTestedNVDAVersion" : "2021.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Prepare for version 2.0, compatible with NVDA 2021.1 and beyond.
### Description of how this pull request fixes the issue:
Update buildVars.py and readme.md.
### Testing performed:
- Check that changes for developers in NVDA don't affect the add-on.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2021.1 and beyond.