### PR TITLE
Disable in secure mode

### DIFF
--- a/addon/globalPlugins/reportPasswords.py
+++ b/addon/globalPlugins/reportPasswords.py
@@ -7,6 +7,7 @@
 import wx
 
 import globalPluginHandler
+import globalVars
 import api
 import config
 import gui

--- a/addon/globalPlugins/reportPasswords.py
+++ b/addon/globalPlugins/reportPasswords.py
@@ -46,7 +46,6 @@ def disableInSecureMode(decoratedCls):
 	return decoratedCls
 
 
-@disableInSecureMode
 class AddonSettingsPanel(SettingsPanel):
 
 	title = ADDON_SUMMARY
@@ -64,6 +63,7 @@ class AddonSettingsPanel(SettingsPanel):
 		config.conf["reportPasswords"]["unprotectControls"] = self.reportPasswordsCheckBox.GetValue()
 
 
+@disableInSecureMode
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def __init__(self):

--- a/addon/globalPlugins/reportPasswords.py
+++ b/addon/globalPlugins/reportPasswords.py
@@ -39,6 +39,13 @@ def addonIsTypingProtected():
 		return True
 
 
+def disableInSecureMode(decoratedCls):
+	if globalVars.appArgs.secure:
+		return globalPluginHandler.GlobalPlugin
+	return decoratedCls
+
+
+@disableInSecureMode
 class AddonSettingsPanel(SettingsPanel):
 
 	title = ADDON_SUMMARY


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Disable the add-on in secure mode.
### Description of how this pull request fixes the issue:
Used code provided by @CyrilleB79 and @lukaszgo1

### Testing performed:
Tested locally. Advisory will be published when patch is rleased.

### Known issues with pull request:
None
### Change log entry:
* Cannot be run in secure mode.