### PR TITLE
Fix deprecation import

### DIFF
--- a/addon/globalPlugins/reportPasswords.py
+++ b/addon/globalPlugins/reportPasswords.py
@@ -11,7 +11,8 @@ import globalVars
 import api
 import config
 import gui
-from gui import SettingsPanel, NVDASettingsDialog, guiHelper
+from gui import guiHelper
+from gui.settingsDialogs import SettingsPanel, NVDASettingsDialog
 from scriptHandler import script
 from globalCommands import SCRCAT_CONFIG
 import addonHandler

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -19,7 +19,7 @@ config.conf.spec["reportPasswords"] = confspec
 
 
 def onInstall():
-	if gui.messageBox(
+	if gui.message.messageBox(
 		_(
 			# Translators: the label of a message box dialog.
 			"If you want to hear typed characters in protected controls like passwords, you need to enable the"


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
SettingsPanel shouldn't be imported directly from gui.
### Description of how this pull request fixes the issue:
- Import SettingsPanel from gui.settingsDialogs
- In installTasks, use gui.message.messageBox instead of gui.messageBox.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None